### PR TITLE
Update main.cpp to fix build error

### DIFF
--- a/tools/noise/src/main.cpp
+++ b/tools/noise/src/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <fstream>
-
+#include <cstdint>
 
 using namespace std;
 


### PR DESCRIPTION
gcc seemed to not want to imply this, so I guess we just have to explicitly include it so it'll build